### PR TITLE
Use env variable for backend URL

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_BACKEND_URL=http://localhost:3001

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -36,6 +36,16 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
 
+## Environment Variables
+
+Create a `.env` file based on `.env.example` and provide the backend URL used by the frontend:
+
+```bash
+cp .env.example .env
+```
+
+Then edit `.env` and set `NEXT_PUBLIC_BACKEND_URL` to the address of the backend server.
+
 # riffly
 MVP for Riffly, an AI native workflow engine for manufacturing. This version replaces manual checklists with automated logging.
  b990c92618bd2b8721a4c73edfbd3bd50a3c14e2

--- a/frontend/src/app_backup/page.tsx
+++ b/frontend/src/app_backup/page.tsx
@@ -23,7 +23,7 @@ export default function Page() {
 
   async function fetchRiffs() {
     try {
-      const res = await axios.get("http://localhost:3001/riffs");
+      const res = await axios.get(`${process.env.NEXT_PUBLIC_BACKEND_URL}/riffs`);
       setRiffs(res.data);
     } catch (error) {
       console.error("Error fetching riffs", error);
@@ -41,7 +41,7 @@ export default function Page() {
     formData.append("caption", caption);
 
     try {
-      await axios.post("http://localhost:3001/upload", formData);
+      await axios.post(`${process.env.NEXT_PUBLIC_BACKEND_URL}/upload`, formData);
       setFile(null);
       setUsername("");
       setCaption("");

--- a/frontend/src/components/NewRiffRecorder.tsx
+++ b/frontend/src/components/NewRiffRecorder.tsx
@@ -58,7 +58,7 @@ export default function NewRiffRecorder({ onUpload }: Props) {
 
     setUploading(true);
     try {
-      await axios.post("http://localhost:3001/upload", formData);
+      await axios.post(`${process.env.NEXT_PUBLIC_BACKEND_URL}/upload`, formData);
       onUpload();
       setAudioUrl(null);
       setCaption("");

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -23,15 +23,17 @@ export default function Dashboard() {
     if (!session) router.replace("/login");
   }, [session, router]);
 
+  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+
   const handleUpload = async () => {
-    if (!mediaBlob) return;
+    if (!mediaBlob || !backendUrl) return;
     setLoading(true);
     const formData = new FormData();
     formData.append("audio", mediaBlob, "recording.wav");
 
     try {
       const res = await fetch(
-        "https://riffly-backend.onrender.com/upload",
+        `${backendUrl}/upload`,
         { method: "POST", body: formData }
       );
       const data = await res.json();
@@ -83,7 +85,7 @@ export default function Dashboard() {
         <div className="mt-6">
           <p className="text-green-600 font-semibold">✅ Inspection complete!</p>
           <a
-            href={`https://riffly-backend.onrender.com/uploads/${downloadLink}`}
+            href={`${backendUrl}/uploads/${downloadLink}`}
             download
             className="text-blue-600 underline"
           >

--- a/frontend/src/pages_backup/index.tsx
+++ b/frontend/src/pages_backup/index.tsx
@@ -21,7 +21,7 @@ export default function Home() {
 
   async function fetchRiffs() {
     try {
-      const res = await axios.get("http://localhost:3001/riffs");
+      const res = await axios.get(`${process.env.NEXT_PUBLIC_BACKEND_URL}/riffs`);
       setRiffs(res.data);
     } catch (error) {
       console.error("Error fetching riffs", error);
@@ -39,7 +39,7 @@ export default function Home() {
     formData.append("caption", caption);
 
     try {
-      await axios.post("http://localhost:3001/upload", formData);
+      await axios.post(`${process.env.NEXT_PUBLIC_BACKEND_URL}/upload`, formData);
       setFile(null);
       setUsername("");
       setCaption("");


### PR DESCRIPTION
## Summary
- add `.env.example` with `NEXT_PUBLIC_BACKEND_URL`
- describe the environment variable in the frontend README
- use `process.env.NEXT_PUBLIC_BACKEND_URL` instead of hard-coded URLs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871bf43134883299201842b7eaacc7f