### PR TITLE
Remove hash from frontend README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,4 +38,3 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 # riffly
 MVP for Riffly, an AI native workflow engine for manufacturing. This version replaces manual checklists with automated logging.
- b990c92618bd2b8721a4c73edfbd3bd50a3c14e2


### PR DESCRIPTION
## Summary
- fix doc by removing stray hash from `frontend/README.md`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871bf449b90832985923a47081b7769