### PR TITLE
Fix openai file upload on Node 18

### DIFF
--- a/backend/index.cjs
+++ b/backend/index.cjs
@@ -35,7 +35,9 @@ app.post('/upload', async (req, res) => {
   const audioFile = req.files.audio;
 
   // Save audio file
-  const fileName = `audio_${Date.now()}.wav`;
+  // Preserve the incoming file extension so Whisper can detect the format
+  const ext = path.extname(audioFile.name) || '.webm';
+  const fileName = `audio_${Date.now()}${ext}`;
   const savePath = path.join(uploadDir, fileName);
 
   try {

--- a/backend/transcription.cjs
+++ b/backend/transcription.cjs
@@ -2,6 +2,13 @@ const fs = require('fs');
 const { OpenAI } = require('openai');
 const { createChecklist } = require('./checklist.cjs');
 
+// Polyfill global File/Blob for Node <20 so openai uploads work
+if (typeof global.File === 'undefined') {
+  const { File, Blob } = require('node:buffer');
+  global.File = File;
+  global.Blob = Blob;
+}
+
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 const UNIT_MAP = {


### PR DESCRIPTION
## Summary
- polyfill File and Blob globals so OpenAI uploads work on Node 18

## Testing
- `npm test` *(fails: Missing package.json)*
- `npm test` in `backend` *(fails: no test script)*
- `npm test` in `frontend` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_687206c96a188329b2f2605fbc191bbe