### PR TITLE
Add Excel annotation upload

### DIFF
--- a/backend/index.cjs
+++ b/backend/index.cjs
@@ -5,7 +5,7 @@ const dotenv = require('dotenv');
 dotenv.config();
 const fs = require('fs');
 const path = require('path');
-const { transcribeAndParse } = require('./transcription.cjs');
+const { transcribeAndParse, transcribeAndAnnotate } = require('./transcription.cjs');
 const { addFile, getFiles, cleanupOldFiles } = require('./db.cjs');
 
 const app = express();
@@ -48,6 +48,37 @@ app.post('/upload', async (req, res) => {
   } catch (err) {
     console.error('❌ Upload or processing failed:', err);
     res.status(500).json({ error: 'Failed to process file.' });
+  }
+});
+
+app.post('/annotate', async (req, res) => {
+  const userId = req.body.userId;
+  if (!userId)
+    return res.status(400).json({ error: 'Missing userId' });
+  if (!req.files || !req.files.audio || !req.files.excel) {
+    return res.status(400).json({ error: 'Audio and Excel files required.' });
+  }
+
+  const audioFile = req.files.audio;
+  const excelFile = req.files.excel;
+
+  const audioExt = path.extname(audioFile.name) || '.webm';
+  const audioName = `audio_${Date.now()}${audioExt}`;
+  const audioPath = path.join(uploadDir, audioName);
+
+  const excelExt = path.extname(excelFile.name) || '.xlsx';
+  const excelName = `excel_${Date.now()}${excelExt}`;
+  const excelPath = path.join(uploadDir, excelName);
+
+  try {
+    await audioFile.mv(audioPath);
+    await excelFile.mv(excelPath);
+    const annotated = await transcribeAndAnnotate(audioPath, excelPath);
+    await addFile(userId, path.basename(annotated));
+    res.json({ download: path.basename(annotated) });
+  } catch (err) {
+    console.error('❌ Annotation failed:', err);
+    res.status(500).json({ error: 'Failed to annotate.' });
   }
 });
 

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -19,6 +19,7 @@ export default function Dashboard() {
   const [downloadLink, setDownloadLink] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [history, setHistory] = useState<string[]>([]);
+  const [excelFile, setExcelFile] = useState<File | null>(null);
 
   useEffect(() => {
     if (!session) router.replace("/login");
@@ -34,6 +35,28 @@ export default function Dashboard() {
     try {
       const res = await fetch(
         "https://riffly-backend.onrender.com/upload",
+        { method: "POST", body: formData }
+      );
+      const data = await res.json();
+      setDownloadLink(data.download ?? null);
+      if (data.download) setHistory((h) => [data.download, ...h]);
+    } catch {
+      alert("⚠️ Upload failed");
+    }
+    setLoading(false);
+  };
+
+  const handleAnnotateUpload = async () => {
+    if (!mediaBlob || !user || !excelFile) return;
+    setLoading(true);
+    const formData = new FormData();
+    formData.append("audio", mediaBlob, "recording.wav");
+    formData.append("excel", excelFile);
+    formData.append("userId", user.id);
+
+    try {
+      const res = await fetch(
+        "https://riffly-backend.onrender.com/annotate",
         { method: "POST", body: formData }
       );
       const data = await res.json();
@@ -80,12 +103,27 @@ export default function Dashboard() {
       )}
 
       {mediaBlob && !loading && !downloadLink && (
-        <button
-          onClick={handleUpload}
-          className="bg-black text-white px-6 py-3 rounded mt-4"
-        >
-          ⬆️ Upload & Generate Excel
-        </button>
+        <div className="mt-4 space-y-3">
+          <button
+            onClick={handleUpload}
+            className="bg-black text-white px-6 py-3 rounded w-full"
+          >
+            ⬆️ Upload & Generate Excel
+          </button>
+          <input
+            type="file"
+            accept=".xlsx"
+            onChange={(e) => setExcelFile(e.target.files?.[0] || null)}
+            className="block w-full border p-2"
+          />
+          <button
+            onClick={handleAnnotateUpload}
+            disabled={!excelFile}
+            className="bg-green-600 text-white px-6 py-3 rounded w-full"
+          >
+            📋 Upload & Annotate Excel
+          </button>
+        </div>
       )}
 
       {loading && <p className="mt-4">⏳ Processing...</p>}


### PR DESCRIPTION
## Summary
- annotate existing Excel files using new endpoint `/annotate`
- add `annotateChecklist` helper for merging transcription data
- expose new `transcribeAndAnnotate` function
- extend dashboard page with file picker and annotate upload button

## Testing
- `npm test` in backend
- `npm test` in frontend

------
https://chatgpt.com/codex/tasks/task_e_687271b933c48329bfadfef380decaa7