### PR TITLE
Fix part column detection

### DIFF
--- a/backend/checklist.cjs
+++ b/backend/checklist.cjs
@@ -100,10 +100,13 @@ async function annotateChecklist(originalPath, data, originalName = null) {
   let tolCol = null;
   sheet.getRow(1).eachCell((cell, col) => {
     const header = String(cell.value || '').toLowerCase();
+
+    if (header.includes('recorded') || header.includes('comment')) return;
+
     if (header.includes('part')) partCol = col;
-    if (header.match(/dimension|target|nominal|value/)) dimCol = col;
-    if (header.includes('unit')) unitCol = col;
-    if (header.match(/tolerance|allowable/)) tolCol = col;
+    if (!dimCol && header.match(/dimension|target|nominal|value/)) dimCol = col;
+    if (!unitCol && header.includes('unit')) unitCol = col;
+    if (!tolCol && header.match(/tolerance|allowable/)) tolCol = col;
   });
 
   const getUnitFromHeader = () => {
@@ -145,6 +148,8 @@ async function annotateChecklist(originalPath, data, originalName = null) {
             if (measured < lower || measured > upper) {
               const diff = measured < lower ? lower - measured : measured - upper;
               sheet.getRow(i).getCell(startCol + 2).value = `Out of spec by ${diff.toFixed(2)} ${targetUnit}`;
+            } else {
+              sheet.getRow(i).getCell(startCol + 2).value = 'In spec';
             }
           }
         }


### PR DESCRIPTION
## Summary
- improve header detection logic for part column
- ensure tolerance results use spec text when within range

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6872e0a7428483299c4c767085cfe14b