### PR TITLE
Add upload excel button after processing

### DIFF
--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -150,6 +150,17 @@ export default function Dashboard() {
           >
             Download Excel Report
           </a>
+          <div className="mt-2">
+            <button
+              onClick={() => {
+                setExcelFile(null);
+                setDownloadLink(null);
+              }}
+              className="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded"
+            >
+              📤 Upload Excel
+            </button>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- add button so users can pick another Excel after downloading a report

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6872f11751488329aac43e087cdf7ffc