### PR TITLE
Add upload excel button after processing

### DIFF
--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -100,23 +100,35 @@ export default function Dashboard() {
         </div>
       )}
 
-      {!isRecording ? (
-        <button
-          onClick={() => {
-            clear();
-            setDownloadLink(null);
-            startRecording();
-          }}
-          className="bg-blue-600 text-white px-6 py-3 rounded"
-        >
-          🎙️ Start Recording
-        </button>
+      {!downloadLink ? (
+        !isRecording ? (
+          <button
+            onClick={() => {
+              clear();
+              setDownloadLink(null);
+              startRecording();
+            }}
+            className="bg-blue-600 text-white px-6 py-3 rounded"
+          >
+            🎙️ Start Recording
+          </button>
+        ) : (
+          <button
+            onClick={stopRecording}
+            className="bg-red-600 text-white px-6 py-3 rounded"
+          >
+            ⏹️ Stop Recording
+          </button>
+        )
       ) : (
         <button
-          onClick={stopRecording}
-          className="bg-red-600 text-white px-6 py-3 rounded"
+          onClick={() => {
+            setExcelFile(null);
+            setDownloadLink(null);
+          }}
+          className="bg-gray-200 hover:bg-gray-300 px-6 py-3 rounded"
         >
-          ⏹️ Stop Recording
+          📤 Upload New File
         </button>
       )}
 


### PR DESCRIPTION
## Summary
- add button so users can pick another Excel after downloading a report

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6872f11751488329aac43e087cdf7ffc