### PR TITLE
Refine post-inspection workflow

### DIFF
--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -86,17 +86,24 @@ export default function Dashboard() {
     <main className="p-6 max-w-xl mx-auto mt-10 text-center font-sans">
       <h1 className="text-2xl font-bold mb-4">Welcome, {user?.email}</h1>
 
-      {!downloadLink && (
+      {!isRecording && (
         <div className="mb-4">
-          <label className="block text-left mb-1 font-medium">
-            Excel file to annotate (optional):
-          </label>
           <input
             type="file"
             accept=".xlsx"
             onChange={(e) => setExcelFile(e.target.files?.[0] || null)}
-            className="block w-full border p-2"
+            id="excel-upload"
+            style={{ display: "none" }}
           />
+          <label
+            htmlFor="excel-upload"
+            className="bg-blue-600 text-white px-6 py-3 rounded cursor-pointer inline-block"
+          >
+            {downloadLink ? "📤 Upload New File" : "📤 Upload File"}
+          </label>
+          {excelFile && (
+            <p className="mt-2 text-sm text-gray-600">{excelFile.name}</p>
+          )}
         </div>
       )}
 
@@ -104,7 +111,7 @@ export default function Dashboard() {
         <button
           onClick={() => {
             clear();
-            setDownloadLink(null);
+            if (downloadLink) setDownloadLink(null);
             startRecording();
           }}
           className="bg-blue-600 text-white px-6 py-3 rounded"


### PR DESCRIPTION
## Summary
- always show Excel file chooser when not recording
- display the same Start Recording button whether or not a report was generated
- clear previous report once recording restarts

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6872f11751488329aac43e087cdf7ffc