### PR TITLE
Add photo capture workflow

### DIFF
--- a/backend/index.cjs
+++ b/backend/index.cjs
@@ -33,13 +33,30 @@ app.post('/upload', async (req, res) => {
   }
 
   const audioFile = req.files.audio;
+  const imageFilesRaw = req.files.images;
+  const timestampsRaw = req.body.timestamps;
   const ext = path.extname(audioFile.name) || '.webm';
   const fileName = `audio_${Date.now()}${ext}`;
   const savePath = path.join(uploadDir, fileName);
+  const imageFiles = imageFilesRaw
+    ? Array.isArray(imageFilesRaw)
+      ? imageFilesRaw
+      : [imageFilesRaw]
+    : [];
+  const timestamps = timestampsRaw ? JSON.parse(timestampsRaw) : [];
+  const savedImages = [];
 
   try {
     await audioFile.mv(savePath);
-    const checklistFile = await transcribeAndParse(savePath);
+    for (let i = 0; i < imageFiles.length; i++) {
+      const img = imageFiles[i];
+      const ext = path.extname(img.name) || '.jpg';
+      const name = `image_${Date.now()}_${i}${ext}`;
+      const imgPath = path.join(uploadDir, name);
+      await img.mv(imgPath);
+      savedImages.push({ path: imgPath, time: Number(timestamps[i] || 0) });
+    }
+    const checklistFile = await transcribeAndParse(savePath, savedImages);
     await addFile(userId, path.basename(checklistFile));
     res.json({ download: path.basename(checklistFile) });
   } catch (err) {
@@ -57,10 +74,20 @@ app.post('/annotate', async (req, res) => {
 
   const audioFile = req.files.audio;
   const excelFile = req.files.excel;
+  const imageFilesRaw = req.files.images;
+  const timestampsRaw = req.body.timestamps;
 
   const audioExt = path.extname(audioFile.name) || '.webm';
   const audioName = `audio_${Date.now()}${audioExt}`;
   const audioPath = path.join(uploadDir, audioName);
+
+  const imageFiles = imageFilesRaw
+    ? Array.isArray(imageFilesRaw)
+      ? imageFilesRaw
+      : [imageFilesRaw]
+    : [];
+  const timestamps = timestampsRaw ? JSON.parse(timestampsRaw) : [];
+  const savedImages = [];
 
   const excelBase = path.basename(excelFile.name);
   const excelExt = path.extname(excelBase) || '.xlsx';
@@ -70,7 +97,20 @@ app.post('/annotate', async (req, res) => {
   try {
     await audioFile.mv(audioPath);
     await excelFile.mv(excelPath);
-    const annotated = await transcribeAndAnnotate(audioPath, excelPath, excelBase);
+    for (let i = 0; i < imageFiles.length; i++) {
+      const img = imageFiles[i];
+      const ext = path.extname(img.name) || '.jpg';
+      const name = `image_${Date.now()}_${i}${ext}`;
+      const imgPath = path.join(uploadDir, name);
+      await img.mv(imgPath);
+      savedImages.push({ path: imgPath, time: Number(timestamps[i] || 0) });
+    }
+    const annotated = await transcribeAndAnnotate(
+      audioPath,
+      excelPath,
+      excelBase,
+      savedImages
+    );
     await addFile(userId, path.basename(annotated));
     res.json({ download: path.basename(annotated) });
   } catch (err) {

--- a/frontend/src/components/CameraModal.tsx
+++ b/frontend/src/components/CameraModal.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState } from "react";
+
+interface Props {
+  open: boolean;
+  facingMode: "environment" | "user";
+  onCapture: (b: Blob) => void;
+  onClose: () => void;
+  onFlip: () => void;
+}
+
+export default function CameraModal({ open, facingMode, onCapture, onClose, onFlip }: Props) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const start = async () => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode }
+        });
+        streamRef.current = stream;
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play();
+        }
+      } catch {
+        setError("Unable to access camera");
+      }
+    };
+
+    start();
+
+    return () => {
+      streamRef.current?.getTracks().forEach(t => t.stop());
+      streamRef.current = null;
+    };
+  }, [open, facingMode]);
+
+  const capture = async () => {
+    if (!videoRef.current) return;
+    const canvas = document.createElement("canvas");
+    canvas.width = videoRef.current.videoWidth;
+    canvas.height = videoRef.current.videoHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.drawImage(videoRef.current, 0, 0, canvas.width, canvas.height);
+    canvas.toBlob((blob) => {
+      if (blob) onCapture(blob);
+      onClose();
+    }, "image/jpeg", 0.95);
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-90 flex flex-col items-center justify-center z-50">
+      <video ref={videoRef} className="w-full max-w-md" playsInline muted />
+      {error && <p className="text-red-500 mt-2">{error}</p>}
+      <div className="mt-4 flex items-center space-x-6">
+        <button
+          onClick={onFlip}
+          className="text-white text-2xl"
+        >
+          🔄
+        </button>
+        <button
+          onClick={capture}
+          className="h-16 w-16 bg-white rounded-full border-4 border-gray-300"
+        />
+        <button
+          onClick={() => {
+            streamRef.current?.getTracks().forEach(t => t.stop());
+            onClose();
+          }}
+          className="text-white text-2xl"
+        >
+          ✖
+        </button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a modal component for capturing photos while recording
- wire camera button into dashboard and send captured images with timestamps
- store images on the server and map them to spoken part numbers
- link saved photos in the generated Excel checklist
- fix unused variable warning in `CameraModal`

## Testing
- `npm test --silent --prefix backend`
- `npm test --silent --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_687338439a408329b06eb6dd06f56000